### PR TITLE
Remove unused CrownIcon import

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,5 @@
 
 import React from 'react';
-import { CrownIcon } from './Icons';
 
 interface HeroProps {
   onExclusiveAccessClick: () => void;


### PR DESCRIPTION
## Summary
- remove the unused `CrownIcon` import from the `Hero` component

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c90f33f1488322990ed659364c703a