### PR TITLE
Bundle React locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,7 @@
         }
       }
     </script>
-  <script type="importmap">
-{
-  "imports": {
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/",
-    "react/": "https://aistudiocdn.com/react@^19.1.1/",
-    "react": "https://aistudiocdn.com/react@^19.1.1"
-  }
-}
-</script>
-</head>
+  </head>
   <body>
     <div id="root"></div>
   </body>

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react-dom": "^19.1.1",
-    "react": "^19.1.1"
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- remove the CDN import map from `index.html` so React resolves from the installed packages
- ensure React and ReactDOM remain declared as project dependencies so Vite bundles them from `node_modules`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9769a1eb4832297a62c436e26a9a1